### PR TITLE
Better documentation for what the halflife is in this plugin.

### DIFF
--- a/classes/AnalyticBridgePopularPosts.php
+++ b/classes/AnalyticBridgePopularPosts.php
@@ -32,28 +32,43 @@ Class AnayticBridgePopularPosts implements Iterator {
 		$this->size = 20;
 		$this->initalized = true;
 
-    }
+	}
 
-    public function query() {
+	public function query() {
 
-    	global $wpdb;
+		global $wpdb;
 
-    	if($this->initalized) :
-    	
-    		// 1: Calculate a ratio coeffient 
+		if($this->initalized) :
+		
+			// 1: Calculate a ratio coeffient 
 			$tday = new DateTime('today',new DateTimeZone('America/Chicago'));
 			$now = new DateTime('',new DateTimeZone('America/Chicago'));
 	
 			$interval = $tday->diff($now);
-	
+
+			// $minutes is hours*60 + $interval->i minutes
 			$minutes = $interval->h * 60 + $interval->i;
-	
+
+			// $ratio is minutes passed today : minutes in today,
+			// A measure of how long today has been
 			$ratio = $minutes / (24*60);
 	
-			/* sql statement that pulls todays sessions, yesterdays 		*/
-			/* sessions and a weighted average of them from the database.	*/
+			/* sql statement that pulls today's sessions, yesterday's
+			 * sessions and a weighted average of them from the database.
+			 *
+			 * A note on the calculation of weighted pageviews, using a simplified equation:
+			 *
+			 * ( ( today's sessions * $ratio ) + ( yesterday's sessions * ( 1 - $ratio ) ) returns the post's sessions count, averaged between the last 24 hours.
+			 * ( sessions count ) * 1/2 ^ ( ( post date - now ) / ( $halflife * 24 ) ) multiplies this post's sessions count by the half-life equation.
+			 * The half-life equation raises 1/2 to the power n, where n is the number of half-lifes elapsed.
+			 * $half-life is set in the plugin options in Settings > Analytic Bridge > Post halflife. It is the half-life of post popularity, in days.
+			 * A post will count half as much every $halflife days.
+			 * ( post date - now ) returns hours.
+			 * ( $halflife * 24 ) returns hours.
+			 * Dividing the post's age by the halflife-hours gives the number of half-lives that have elapsed, and thus the power that 1/2 should be raised to.
+			 */
 	
-    		$this->result = $wpdb->get_results("
+			$this->result = $wpdb->get_results("
 	
 				--							---
 				--  SELECT POPULAR POSTS 	---
@@ -61,24 +76,27 @@ Class AnayticBridgePopularPosts implements Iterator {
 	
 				SELECT
 	
-					pg.pagepath AS pagepath, 
+					pg.pagepath AS pagepath,
 					pg.id AS page_id,
-					pst.id AS post_id, 
-					coalesce(t.sessions, 0) AS today_pageviews, 
-					coalesce(y.sessions, 0) AS yesterday_pageviews, 
+					pst.id AS post_id,
+					-- coalesce returns the first result that is not NULL:
+					-- either the sessions count or zero
+					coalesce(t.sessions, 0) AS today_pageviews,
+					coalesce(y.sessions, 0) AS yesterday_pageviews,
 	
 					-- calculate the weighted session averages.
 	
-					( -- Calculate avg_pageviews.
-						(coalesce(t.sessions, 0) * $ratio) + 
+					( -- Calculate avg_pageviews in the last 24 hours
+						(coalesce(t.sessions, 0) * $ratio) +
 						(coalesce(y.sessions, 0) * (1 - $ratio))
 					) AS `avg_pageviews`,
 					
-					( -- Calulate days_old
+					( -- Calulate how many days_old the post is
 						TIMESTAMPDIFF( hour, pst.post_date, NOW() ) - 1
 					) AS `days_old`,
 					
-					( -- Calculate weighted_pageviews
+					( -- Calculate weighted_pageviews, using halflife to put less emphasis
+					  -- on older posts
 						(
 							(coalesce(t.sessions, 0) * $ratio) + 
 							(coalesce(y.sessions, 0) * (1 - $ratio))
@@ -168,33 +186,33 @@ Class AnayticBridgePopularPosts implements Iterator {
 
 
 
-    }
+	}
 
-    /**
-     * Returns a score specified by the given $pid.
-     * 
-     * If the $pid is not in this list, returns false.
-     * 
-     * @since v0.1
-     */
-    public function score($pid) {
+	/**
+	 * Returns a score specified by the given $pid.
+	 * 
+	 * If the $pid is not in this list, returns false.
+	 * 
+	 * @since v0.1
+	 */
+	public function score($pid) {
 
-    	foreach($this as $popularPost) 
-    		if ($popularPost->post_id == $pid) 
+		foreach($this as $popularPost) 
+			if ($popularPost->post_id == $pid) 
 				return $popularPost->weighted_pageviews;
-    		
-    	return false;
+			
+		return false;
 
-    }
+	}
 
-    private function setIds() {
-    	$this->ids = array();
-    	foreach($this as $popPost) {
-    		$this->ids[] = $popPost->post_id;
-    	}
-    }
+	private function setIds() {
+		$this->ids = array();
+		foreach($this as $popPost) {
+			$this->ids[] = $popPost->post_id;
+		}
+	}
 
-    /** Region: Iterator functions */
+	/** Region: Iterator functions */
 
 	public function rewind() {
 

--- a/inc/analytic-bridge-blog-options.php
+++ b/inc/analytic-bridge-blog-options.php
@@ -304,7 +304,7 @@ function analyticbridge_register_options() {
 	// Add property field
 	add_settings_field(
 		'analyticbridge_setting_popular_posts_halflife',
-		'Post halflife',
+		'Post halflife (in days)',
 		'analyticbridge_setting_popular_posts_halflife_input',
 		'analytic-bridge',
 		'largo_anaytic_bridge_popular_posts_settings_section'
@@ -345,7 +345,8 @@ function largo_anaytic_bridge_account_settings_section_intro() {
  * @since v0.1
  */
 function largo_anaytic_bridge_popular_posts_settings_section_intro() {
-	echo '<p>Enter the half life that popular post pageview weight should degrade by.</p>';
+	echo '<p>The post halflife is a measure of how long more-popular posts should remain in the popular posts list.</p>';
+	echo '<p>For example, with a half-life setting of 14 days, a post that is two weeks old and has 200 views in the last 24 hours will be as valuable as a post that is 1 day old and has 100 views in the last 24 hours.</p>';
 }
  
 

--- a/inc/analytic-bridge-blog-options.php
+++ b/inc/analytic-bridge-blog-options.php
@@ -457,5 +457,5 @@ function analyticbridge_setting_account_profile_id_input() {
  * @since v0.1
  */ 
 function analyticbridge_setting_popular_posts_halflife_input() {
-	echo '<input name="analyticbridge_setting_popular_posts_halflife" id="analyticbridge_setting_popular_posts_halflife" type="text" value="' . get_option('analyticbridge_setting_popular_posts_halflife') . '" class="regular-text" />';
+	echo '<input name="analyticbridge_setting_popular_posts_halflife" id="analyticbridge_setting_popular_posts_halflife" type="number" value="' . get_option('analyticbridge_setting_popular_posts_halflife') . '" class="regular-text" />';
 }


### PR DESCRIPTION
## Changes
- Some spaces to tabs
- PHP comment explaining what in the world is going on with the post-getting criteria
- Half-life setting in plugin admin becomes a `number` input type instead of `text`
- Changes to plugin settings better explaining what the half-life is

<img width="883" alt="screen shot 2015-10-27 at 12 19 05 pm" src="https://cloud.githubusercontent.com/assets/1754187/10765210/02066982-7ca8-11e5-93ba-7415f33fcf33.png">
## Why

For our own understanding of how this works.
