### PR TITLE
Remove metrics records older than 2 days

### DIFF
--- a/AnalyticBridgeGoogleClient.php
+++ b/AnalyticBridgeGoogleClient.php
@@ -1,34 +1,34 @@
 <?php
 
 class AnalyticBridge {
- 
-	/** 
-	 * Refers to a single instance of this class. 
+
+	/**
+	 * Refers to a single instance of this class.
 	 */
 	private static $instance = null;
 
-	/** 
-	 * Refers to a single instance of this class. 
+	/**
+	 * Refers to a single instance of this class.
 	 */
 	private $client;
 
 	private $clientAuthenticated;
-	
+
 	/**
 	 * Creates or returns an instance of this class.
 	 *
 	 * @return AnalyticBridge Object A single instance of this class.
 	 */
 	public static function get_instance() {
-	
+
 		if ( null == self::$instance ) {
 			self::$instance = new self;
 		}
-	
+
 		return self::$instance;
-	
+
 	} // end get_instance;
-	
+
 	/**
 	 * Initializes the plugin by setting localization, filters, and administration functions.
 	 */
@@ -36,27 +36,27 @@ class AnalyticBridge {
 
 		$this->client = null;
 		$this->clientAuthenticated = false;
-	
+
 	} // end constructor
 
 	/**
 	 * Attempts to authenticate with google's servers.
-	 * 
-	 * Pulls the access_token and refresh_token provided by google from the 
+	 *
+	 * Pulls the access_token and refresh_token provided by google from the
 	 * database and authenticates a google client.
-	 * 
+	 *
 	 * On success, returns a google_client object that's pre authenticated and loaded
 	 * with the right scopes to access analytic data and email/name of the authenticated.
-	 * 
+	 *
 	 * On failure, returns false.
-	 * 
+	 *
 	 * @since v0.1
-	 * 
-	 * @param boolean $auth whether we should try to authenticate the client or just set it up 
+	 *
+	 * @param boolean $auth whether we should try to authenticate the client or just set it up
 	 *		with the right scopes.
-	 * @param array $e passed by reference. If provided, $e will contain error information 
+	 * @param array $e passed by reference. If provided, $e will contain error information
 	 *		if authentication fails.
-	 * 
+	 *
 	 * @return Google_Client object on success, 'false' on failure.
 	 */
 	public function getClient($auth = true,&$e = null) {
@@ -67,7 +67,7 @@ class AnalyticBridge {
 
 		// We want to authenticate and there is no auth ticket or refresh token.
 		if( $auth && !(get_option('analyticbridge_access_token') && get_option('analyticbridge_refresh_token')) ) :
-			
+
 			if( $e ) {
 				$e = array();
 				$e['message'] = 'No access token. Get a system administrator to authenticate the Analytic Bridge.';
@@ -86,7 +86,7 @@ class AnalyticBridge {
 			return false;
 
 		// We have everything we need.
-		else : 
+		else :
 
 			// Create a Google Client.
 
@@ -101,14 +101,14 @@ class AnalyticBridge {
 			$client->setAccessType("offline");
 			$client->setScopes(
 				array(
-					'https://www.googleapis.com/auth/analytics.readonly', 
-					'https://www.googleapis.com/auth/userinfo.email', 
+					'https://www.googleapis.com/auth/analytics.readonly',
+					'https://www.googleapis.com/auth/userinfo.email',
 					'https://www.googleapis.com/auth/userinfo.profile'
 				)
 			);
 
-			/* 
-			 * If there's an access token set, try to authenticate with it. 
+			/*
+			 * If there's an access token set, try to authenticate with it.
 			 * Otherwise we just return without any authenticating.
 			 */
 			if( $auth ) :
@@ -121,12 +121,12 @@ class AnalyticBridge {
 						update_option('analyticbridge_access_token',$client->getAccessToken());
 					}
 					$this->clientAuthenticated = true;
-				
+
 				} catch(Google_Auth_Exception $error) {
-					
+
 					// return (by reference) error information.
-					if ( $e ) { 
-						$e = $error; 
+					if ( $e ) {
+						$e = $error;
 					}
 
 					$this->clientAuthenticated = false;
@@ -143,19 +143,19 @@ class AnalyticBridge {
 
 		endif;
 	}
- 
+
 }
 
 /**
  * Attempts to authenticate with google's servers.
- * 
+ *
  * @see AnalyticBridge->getClient() for full documentation.
- * 
+ *
  * @since v0.1
- * 
- * @param boolean $auth whether we should try to authenticate the client or just set it up 
+ *
+ * @param boolean $auth whether we should try to authenticate the client or just set it up
  *		with the right scopes.
- * @param array $e passed by reference. If provided, $e will contain error information 
+ * @param array $e passed by reference. If provided, $e will contain error information
  *		if authentication fails.
  * @return Google_Client object on success, 'false' on failure.
  */
@@ -166,19 +166,19 @@ function analytic_bridge_google_client($auth = true,&$e = null) {
 
 /**
  * Used the first time a user is authenticating.
- * 
+ *
  * Attempts to authenticate a new google client for the first time and
  * saves an access and refresh token to the database before returning the client.
- * 
+ *
  * @since 0.1
- * 
- * @param String $code 
+ *
+ * @param String $code
  */
 function analytic_bridge_authenticate_google_client($code, &$e = null) {
 
 	// get a new unauthenticated google client.
 	$client = analytic_bridge_google_client(false,$e);
-	
+
 	// If we didn't get a client (for whatever reason) return false.
 	if(!$client)
 		return false;
@@ -214,9 +214,9 @@ function analyticbridge_client_secret() {
 
 /**
  * If API tokens are defined for the network return true. Else, return false.
- * 
+ *
  * @since v0.1
- * 
+ *
  * @return boolean true if network api tokens are defined, false if otherwise.
  */
 function analyticbridge_using_network_api_tokens() {

--- a/Analytic_Bridge_Service.php
+++ b/Analytic_Bridge_Service.php
@@ -1,7 +1,7 @@
 <?php
 
 Class Analytic_Bridge_Service extends Google_Service_Analytics {
-	
+
 	public function timezone(&$report) {
 
 		$profileInfo = $report->getProfileInfo();

--- a/analytic-bridge-options.php
+++ b/analytic-bridge-options.php
@@ -4,7 +4,7 @@ require_once( plugin_dir_path( __FILE__ ) . '../AnalyticBridgeGoogleClient.php')
 require_once( plugin_dir_path( __FILE__ ) . '../analytic-bridge.php');
 
 
-/** 
+/**
  * ================================================================================================
  *	 #region: network option page.
  * ================================================================================================
@@ -31,12 +31,12 @@ add_action( 'network_admin_menu', 'analyticbridge_network_plugin_menu' );
 
 /**
  * Output the html for the *network* option page.
- * 
+ *
  * @since v0.1
  */
 function analyticbridge_network_option_page_html() {
 
-	if(!current_user_can('manage_network_options')) 
+	if(!current_user_can('manage_network_options'))
 		wp_die("Sorry, you don't have permission to do this");
 	echo '<div class="wrap">';
 	echo '<h2>Network Analytic Bridge Options</h2>';
@@ -77,7 +77,7 @@ function analyticbridge_update_network_options(){
 add_action('admin_post_network-analytic-bridge-options',  'analyticbridge_update_network_options');
 
 
-/** 
+/**
  * ================================================================================================
  *	 #region: blog option page(s).
  * ================================================================================================
@@ -102,7 +102,7 @@ add_action( 'admin_menu', 'analyticbridge_plugin_menu' );
 
 /**
  * Output the HTML for the Analytic Bridge option page.
- * 
+ *
  * If a $_GET variable is posted back to the page (by Google), it's stored as an option.
  *
  * @since v0.1
@@ -165,7 +165,7 @@ function analyticbridge_option_page_html() {
 		endif;
 
 	else :
-	
+
 		echo "Enter your API details";
 
 	endif;
@@ -196,7 +196,7 @@ function analyticbridge_register_options() {
 			'largo_anaytic_bridge_api_settings_section_intro',
 			'analytic-bridge'
 		); // ($id, $title, $callback, $page)
-		
+
 		// Add Client ID field.
 		add_settings_field(
 			'analyticbridge_setting_api_client_id',
@@ -205,7 +205,7 @@ function analyticbridge_register_options() {
 			'analytic-bridge',
 			'largo_anaytic_bridge_api_settings_section'
 		); // ($id, $title, $callback, $page, $section, $args)
-		
+
 		// Add Client Secret field
 		add_settings_field(
 			'analyticbridge_setting_api_client_secret',
@@ -214,11 +214,11 @@ function analyticbridge_register_options() {
 			'analytic-bridge',
 			'largo_anaytic_bridge_api_settings_section'
 		); // ($id, $title, $callback, $page, $section, $args)
-	
+
 		// Register our settings.
 		register_setting( 'analytic-bridge', 'analyticbridge_setting_api_client_id' );
 		register_setting( 'analytic-bridge', 'analyticbridge_setting_api_client_secret' );
-	
+
 	}
 
 	/* ------------------------------------------------------------------------------------------
@@ -279,7 +279,7 @@ function analyticbridge_register_options() {
 
 }
 add_action('admin_init', 'analyticbridge_register_options');
-  
+
 /**
  * Intro text for our google api settings section.
  *
@@ -311,13 +311,13 @@ function largo_anaytic_bridge_account_settings_section_intro() {
 function largo_anaytic_bridge_popular_posts_settings_section_intro() {
 	echo '<p>Enter the half life that popular post pageview weight should degrade by.</p>';
 }
- 
+
 
 /**
  * Prints input field for Google Client ID setting.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_api_client_id_input() {
 	echo '<input name="analyticbridge_setting_api_client_id" id="analyticbridge_setting_api_client_id" type="text" value="' . analyticbridge_client_id() . '" class="regular-text" />';
 }
@@ -326,7 +326,7 @@ function analyticbridge_setting_api_client_id_input() {
  * Prints input field for Google Client Secret setting.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_api_client_secret_input() {
 	echo '<input name="analyticbridge_setting_api_client_secret" id="analyticbridge_setting_api_client_secret" type="text" value="' . analyticbridge_client_secret() . '" class="regular-text" />';
 }
@@ -335,7 +335,7 @@ function analyticbridge_setting_api_client_secret_input() {
  * Prints input field for Google Profile ID to pull data from.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_account_profile_id_input() {
 	echo '<input name="analyticbridge_setting_account_profile_id" id="analyticbridge_setting_account_profile_id" type="text" value="' . get_option('analyticbridge_setting_account_profile_id') . '" class="regular-text" />';
 }
@@ -344,7 +344,7 @@ function analyticbridge_setting_account_profile_id_input() {
  * Prints input field for Popular Post halflife.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_popular_posts_halflife_input() {
 	echo '<input name="analyticbridge_setting_popular_posts_halflife" id="analyticbridge_setting_popular_posts_halflife" type="text" value="' . get_option('analyticbridge_setting_popular_posts_halflife') . '" class="regular-text" />';
 }

--- a/analytic-bridge.php
+++ b/analytic-bridge.php
@@ -30,7 +30,7 @@ require_once( plugin_dir_path( __FILE__ ) . 'Analytic_Bridge_Service.php');
 /**
  * Registers admin option page and populates with
  * plugin settings.
- */ 
+ */
 require_once( plugin_dir_path( __FILE__ ) . 'inc/analytic-bridge-network-options.php');
 require_once( plugin_dir_path( __FILE__ ) . 'inc/analytic-bridge-blog-options.php');
 
@@ -45,7 +45,7 @@ include_once(plugin_dir_path( __FILE__ ) .'inc/analytic-bridge-installing.php');
 
 /**
  * Add new intervals for cron jobs.
- * 
+ *
  * @since 0.1
  */
 function new_interval($interval) {
@@ -62,7 +62,7 @@ function new_interval($interval) {
 add_filter('cron_schedules', 'new_interval');
 
 
-/** 
+/**
  * ----------------------------------------------------------------------------------------------
  * Step 2: Connect to Google & create an api token.
  * ----------------------------------------------------------------------------------------------
@@ -74,19 +74,19 @@ function largo_die($e) {
 }
 
 function largo_pre_print($pre) {
-	echo "<pre style='background:#fff;border:1px solid #eee;overflow-y:scroll'>";	
+	echo "<pre style='background:#fff;border:1px solid #eee;overflow-y:scroll'>";
 	print_r($pre);
 	echo "</pre>";
 }
 
 /**
  * A cron job that loads data from google analytics into out analytic tables.
- * 
+ *
  * @since v0.2
- * 
+ *
  * @uses get_site_url
- * 
- * @param boolean $verbose set to true to print 
+ *
+ * @param boolean $verbose set to true to print
  */
 function largo_anaylticbridge_cron($verbose = false) {
 
@@ -103,7 +103,7 @@ function largo_anaylticbridge_cron($verbose = false) {
 	// 1: Create an API client.
 
 	$client = analytic_bridge_google_client(true,$e);
-			
+
 	if($client == false) {
 		if($verbose) echo("[Error] creating api client, message: " . $e["message"] . "\n");
 		if($verbose) echo("\nEnd analyticbridge_cron\n");
@@ -122,7 +122,7 @@ function largo_anaylticbridge_cron($verbose = false) {
 	function rutime($ru, $rus, $index) {
 		return ($ru["ru_$index.tv_sec"]*1000 + intval($ru["ru_$index.tv_usec"]/1000)) - ($rus["ru_$index.tv_sec"]*1000 + intval($rus["ru_$index.tv_usec"]/1000));
 	}
-		
+
 	$ru = getrusage();
 	if($verbose) echo "\nThis process used " . rutime($ru, $rustart, "utime") . " ms for its computations\n";
 	if($verbose) echo "It spent " . rutime($ru, $rustart, "stime") . " ms in system calls\n";
@@ -135,10 +135,10 @@ add_action( 'analyticbridge_hourly_cron', 'largo_anaylticbridge_cron' );
 
 /**
  * Queries analytics and saves them to the table for the given start date.
- * 
+ *
  * If the start and end dates already exist in the table, it first clears
  * them out and refreshes the values.
- * 
+ *
  * @param boolean $verbose whether we should print while we do it.
  */
 function query_and_save_analytics($analytics,$startdate,$verbose = false) {
@@ -156,7 +156,7 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 					$start,
 					$start,
 					"ga:sessions,ga:pageviews,ga:exits,ga:bounceRate,ga:avgSessionDuration,ga:avgTimeOnPage",
-					array( 
+					array(
 					  "dimensions" => "ga:pagePath",
 					  'max-results' => '1000',
 					  'sort' => '-ga:sessions'
@@ -167,7 +167,7 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 		echo "returned report:\n\n";
 		echo " - itemsPerPage: " . $report->itemsPerPage . "\n";
 		echo " - row count: " . sizeof($report->rows) . "\n\n";
-	} 
+	}
 
 	// Get google's timezone. Save it in case we need it later.
 
@@ -179,7 +179,7 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 
 	// Start a mysql transaction, in a try catch.
 	try {
-	
+
 		// $wpdb->query('START TRANSACTION');
 
 		// Begin our sql statement.
@@ -188,15 +188,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 
 		// caching iterator contains hasNext() functionality.
 		$iter = new CachingIterator(new ArrayIterator($report->rows));
-		
+
 		foreach($iter as $r) :
-		
+
 			// $r[0] - pagePath
 			$gapath = $r[0];
-	
+
 			// map google url path the wordpress path.
 			$wpurl = get_home_url() . preg_replace('/index.php$/', '', $gapath);
-	
+
 			// try to determine the $postid.
 			$postid = url_to_postid( $wpurl );
 
@@ -215,28 +215,28 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 				//   - /sports/2015/04/23/heres-the-slug/index.php
 				//   - /index.php?p=118468&preview=true
 				//   - &c.
-				// 
+				//
 				// So that something like a preview page doesn't overwrite its low metrics
 				// with the actual count we catch it here and do nothing with it.
 				// everything else follows the else.
-				// 
+				//
 
 			} else {
-	
+
 				// Insert into our 'post' table the pagepath and related postid
 				// (if it doesn't exist).
 				// Update `id` so that mysql_last_inserted is set.
 				$pagesql .= $wpdb->prepare(
 						"\t(%s, %s)", $gapath, $postid
 					);
-	
+
 				// Adjust things to save based on the google analytics timezone.
 				$tstart = new DateTime($startdate,new DateTimeZone($gaTimezone));
 				$tend = new DateTime($startdate,new DateTimeZone($gaTimezone));
-	
+
 				// The time that the query happened (± a few seconds).
 				$qTime = new DateTime('now',new DateTimeZone($gaTimezone));
-	
+
 				// $r[1] - ga:sessions
 				// $r[2] - ga:pageviews
 				// $r[3] - ga:exits
@@ -246,8 +246,8 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 
 				// Insert ga:sessions
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -255,15 +255,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:sessions', $r[1], $r[1]
-	
+
 					);
-	
+
 				$metricsql .= ", \n";
-	
+
 				// Insert ga:pageviews
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -271,15 +271,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:pageviews', $r[2], $r[2]
-	
+
 					);
-	
+
 				$metricsql .= ", \n";
-	
+
 				// Insert ga:exits
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -287,15 +287,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:exits', $r[3], $r[3]
-	
+
 					);
-	
+
 				$metricsql .= ", \n";
-	
+
 				// Insert ga:bouncerate
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -303,15 +303,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:bounceRate', $r[4], $r[4]
-	
+
 					);
-	
+
 				$metricsql .= ", \n";
-	
+
 				// Insert ga:avgSessionDuration
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -319,15 +319,15 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:avgSessionDuration', $r[5], $r[5]
-	
+
 					);
-	
+
 				$metricsql .= ", \n";
-	
+
 				// Insert ga:avgTimeOnPage
 				$metricsql .= $wpdb->prepare(
-	
-						"( 
+
+						"(
 							(SELECT `id` from " . PAGES_TABLE . " WHERE `pagepath`=%s),
 							%s,
 							%s,
@@ -335,9 +335,9 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 							%s,
 							%s)
 						", $r[0], date_format($tstart, 'Y-m-d'), date_format($tend, 'Y-m-d'), date_format($qTime, 'Y-m-d H:i:s'), 'ga:avgTimeOnPage', $r[6], $r[6]
-	
+
 					);
-	
+
 				if($iter->hasNext()) {
 					$pagesql .= ", \n";
 					$metricsql .= ", \n";
@@ -370,7 +370,7 @@ function query_and_save_analytics($analytics,$startdate,$verbose = false) {
 
 /**
  * Static logging class for cron jobs.
- * 
+ *
  */
 Class AnalyticBridgeLog {
 
@@ -382,11 +382,11 @@ Class AnalyticBridgeLog {
 
 		if( !WP_DEBUG )
 			return;
-		
+
 		if( $date === null ) {
 			$date = new DateTime('now', new DateTimeZone('America/Chicago'));
 		}
-		
+
 		$time = $date->format('D M d h:i:s');
 		$log = "[$time] $log\n";
 
@@ -397,13 +397,13 @@ Class AnalyticBridgeLog {
 
 /**
  * Class to fake Google Analytics requests.
- * 
+ *
  * This class extends Google_Service_Analytics and fakes requests to the
  * Google API for debugging by generating data based on the global Wordpress
  * object.
- * 
+ *
  * Needs work.
- * 
+ *
  * @since v0.1
  */
 class Google_Service_Analytics_Generator extends Google_Service_Analytics {
@@ -412,10 +412,10 @@ class Google_Service_Analytics_Generator extends Google_Service_Analytics {
 
 	/**
 	 * Construct a new Analytics Generator.
-	 * 
+	 *
 	 * data_ga is set to ourselves. We handle the get function
 	 * internally.
-	 * 
+	 *
 	 * @since v0.1
 	 */
 	public function __construct(Google_Client $client) {
@@ -424,20 +424,20 @@ class Google_Service_Analytics_Generator extends Google_Service_Analytics {
 
 	/**
 	 * Overrided Google_Service_Analytics_DataGa_Resource get function.
-	 * 
+	 *
 	 * @return Google_Service_Analytics_GaData Object with proper row values.
 	 */
 	public function get($ids, $startDate, $endDate, $metrics, $optParams = array()) {
 
 		$rows = array();
 		$metrics = explode(",",$metrics);
-		
+
 		$the_query = new WP_Query(  array( 'post_type' => 'post') );
 
 		if ( $the_query->have_posts() ) :
 
 			while ( $the_query->have_posts() ) : $the_query->the_post();
-	
+
 				$r = array();
 				$url = parse_url(get_permalink());
 				$r[0] = $url['path'] . $url['query'];
@@ -463,9 +463,9 @@ class Google_Service_Analytics_Generator extends Google_Service_Analytics {
 				}
 
 				$rows[] = $r;
-	
+
 			endwhile;
-		
+
 			wp_reset_postdata();
 
 		endif;

--- a/classes/AnalyticBridgePopularPosts.php
+++ b/classes/AnalyticBridgePopularPosts.php
@@ -4,10 +4,10 @@ Class AnayticBridgePopularPosts implements Iterator {
 
 	// array of results.
 	private $result;
-	
+
 	// used by iterator.
 	private $position;
-	
+
 	// was a valid query executed?
 	public $queried;
 
@@ -47,7 +47,7 @@ Class AnayticBridgePopularPosts implements Iterator {
 
 			/* sql statement that pulls todays sessions, yesterdays 		*/
 			/* sessions and a weighted average of them from the database.	*/
-			$this->result = $wpdb->get_results("
+			$SQL = "
 				--							---
 				--  SELECT POPULAR POSTS 	---
 				--							---
@@ -119,7 +119,9 @@ Class AnayticBridgePopularPosts implements Iterator {
 				WHERE `pst`.`post_type` = 'post'
 					ORDER BY `weighted_pageviews` DESC
 					LIMIT $this->size
-			");
+			";
+
+			$this->result = $wpdb->get_results($SQL);
 
 			$this->queried = true;
 			$this->setIds();

--- a/inc/analytic-bridge-blog-options.php
+++ b/inc/analytic-bridge-blog-options.php
@@ -1,42 +1,44 @@
 <?php
-/** 
+/**
  * Blog option page.
- * 
+ *
  * @package Analytic Bridge
  */
 
 /**
  * Enqueue style for admin page.
- * 
+ *
  */
 function analyticbridge_blog_options_admin_style($hook) {
-	if($hook == 'settings_page_analytic-bridge')
-		wp_enqueue_style( 'analyticbridge_admin_style', plugins_url('css/admin.css', dirname(__FILE__)), false, '0.1' );
+	if ( $hook == 'settings_page_analytic-bridge' ) {
+		wp_enqueue_style(
+			'analyticbridge_admin_style',
+			plugins_url( 'css/admin.css', dirname( __FILE__ ) ),
+			false,
+			'0.1'
+		);
+	}
 }
 add_action( 'admin_enqueue_scripts', 'analyticbridge_blog_options_admin_style' );
 
 /**
  * Google Analytics Embed API.
- * 
+ *
  * @see https://developers.google.com/analytics/devguides/reporting/embed/v1/devguide
  */
-function analyticbridge_blog_options_admin_head() { 
+function analyticbridge_blog_options_admin_head() {
 
 	/* We only give the selector to the user that authenticated in the first place */
 
 	$current_user = wp_get_current_user();
-	if( $current_user->ID != get_option('analyticbridge_authenticated_user') )
+	if ( $current_user->ID != get_option('analyticbridge_authenticated_user') ) {
 		return;
-
+	}
 
 	$client = analytic_bridge_google_client();
-
-	print_r($client);
-
-	?>
-
+	$accessToken = json_decode( get_option('analyticbridge_access_token') );
+?>
 	<!-- Google Analytics Embed API -->
-
 	<script>
 	(function(w,d,s,g,js,fjs){
 	  g=w.gapi||(w.gapi={});g.analytics={q:[],ready:function(cb){this.q.push(cb)}};
@@ -44,61 +46,33 @@ function analyticbridge_blog_options_admin_head() {
 	  js.src='https://apis.google.com/js/platform.js';
 	  fjs.parentNode.insertBefore(js,fjs);js.onload=function(){g.load('analytics')};
 	}(window,document,'script'));
-
 	</script>
 
 	<script>
 	gapi.analytics.ready(function() {
-	
 	  // 1: Authorize the user.
-	
 	  var CLIENT_ID = '<?php echo analyticbridge_client_id() ?>';
-	
+
 	  gapi.analytics.auth.authorize({
 		container: 'auth-button',
 		clientid: CLIENT_ID,
 		serverAuth: {
-			<?php
-
-			$accessToken = json_decode( get_option('analyticbridge_access_token') );
-
-			?>
 			access_token: '<?php echo $accessToken->access_token;?>',
 		}
 	  });
-	
+
 	// 2: Create the view selector.
-	
 	jQuery('input[name=analyticbridge_setting_account_profile_id]').before(jQuery('<div id="google-view-selector"></div>'));
 	var currentView = jQuery('input[name=analyticbridge_setting_account_profile_id]').attr('value');
 	var viewSelector = new gapi.analytics.ViewSelector({
 	  container: 'google-view-selector',
 	  ids: {currentView}
 	});
-	//viewSelector.set({ids:currentView});
-	/*
-	jQuery('input[name=analyticbridge_setting_account_profile_id]').prop('disabled', true).css({
-		background: 'rgba(0,0,0,.08)',
-		color: '#000'
-	});
-*/
 
 	// 3: Hook it all up.
-	
 	var loaded = false;
-
 	viewSelector.once('change',function(ids) {
-		//viewSelector.ids = currentView;
-		
-		//console.log(viewSelector.get());
-		//viewSelector.set({ids:currentView});
-		
-		//viewSelector.set({ids:currentView});
-		//viewSelector.execute();
-
-
 		viewSelector.on('change', function(ids) {
-			console.log(ids);
 			jQuery('input[name=analyticbridge_setting_account_profile_id]').attr('value',ids);
 		});
 	});
@@ -106,10 +80,7 @@ function analyticbridge_blog_options_admin_head() {
 	viewSelector.execute();
 
 	});
-
-	</script>
-
-	<?php
+	</script><?php
 }
 add_action( 'admin_footer', 'analyticbridge_blog_options_admin_head' );
 
@@ -119,7 +90,7 @@ add_action( 'admin_footer', 'analyticbridge_blog_options_admin_head' );
  * @since v0.1
  */
 function analyticbridge_plugin_menu() {
-	add_options_page( 
+	add_options_page(
 		'Analytic Bridge Options', 					// $page_title title of the page.
 		'Analytic Bridge', 							// $menu_title the text to be used for the menu.
 		'manage_options', 							// $capability required capability for display.
@@ -131,7 +102,7 @@ add_action( 'admin_menu', 'analyticbridge_plugin_menu' );
 
 /**
  * Output the HTML for the Analytic Bridge option page.
- * 
+ *
  * If a $_GET variable is posted back to the page (by Google), it's stored as an option.
  *
  * @since v0.1
@@ -151,51 +122,40 @@ function analyticbridge_option_page_html() {
 	echo '</form>';
 
 	// check if there is a client id/secret defined.
-
-	if(analyticbridge_client_id() && analyticbridge_client_secret()) :
+	if ( analyticbridge_client_id() && analyticbridge_client_secret() ) {
 
 		/* Google has posted an authenticate code back to us. */
-		if ( isset($_GET['code']) ) :
+		if ( isset($_GET['code']) ) {
 			$client = analytic_bridge_authenticate_google_client($_GET['code']);
 			$redirect = 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
 			header('Location: ' . filter_var($redirect, FILTER_SANITIZE_URL));
-
 		// No auth ticket loaded (yet).
-		elseif( !get_option('analyticbridge_access_token') ) :
+		} elseif ( !get_option('analyticbridge_access_token') ) {
 			$client = analytic_bridge_google_client(false);
 			echo "<a href='" . $client->createAuthUrl() . "'>Connect</a>";
-
-		else :
+		} else {
 			$client = analytic_bridge_google_client();
 			$service = new Google_Service_Oauth2($client);
 			$user = $service->userinfo->get();
 			echo "Connected as " . $user->getEmail();
-
-		endif;
+		}
 
 		/* The user has asked us to run the cron. */
-		if( isset($_GET['update']) ) :
-
+		if ( isset($_GET['update']) ) {
 			echo "<h3>Running Update...</h3>";
 			echo "<pre>";
 				echo "Running cron...";
 				largo_anaylticbridge_cron(true);
 			echo "</pre>";
-
-		else :
-
+		} else {
 			echo "<h3>Update Analytics</h3>";
 			echo "<pre>";
 				echo '<a href="' . admin_url('options-general.php?page=analytic-bridge&update'). '">Update analytics</a>';
 			echo "</pre>";
-
-		endif;
-
-	else :
-	
+		}
+	} else {
 		echo "Enter your API details";
-
-	endif;
+	}
 
 	echo '</div>'; // div.wrap
 
@@ -223,7 +183,7 @@ function analyticbridge_register_options() {
 			'largo_anaytic_bridge_api_settings_section_intro',
 			'analytic-bridge'
 		); // ($id, $title, $callback, $page)
-		
+
 		// Add Client ID field.
 		add_settings_field(
 			'analyticbridge_setting_api_client_id',
@@ -232,7 +192,7 @@ function analyticbridge_register_options() {
 			'analytic-bridge',
 			'largo_anaytic_bridge_api_settings_section'
 		); // ($id, $title, $callback, $page, $section, $args)
-		
+
 		// Add Client Secret field
 		add_settings_field(
 			'analyticbridge_setting_api_client_secret',
@@ -254,7 +214,7 @@ function analyticbridge_register_options() {
 		// Register our settings.
 		register_setting( 'analytic-bridge', 'analyticbridge_setting_api_client_id' );
 		register_setting( 'analytic-bridge', 'analyticbridge_setting_api_client_secret' );
-	
+
 	}
 
 	/* ------------------------------------------------------------------------------------------
@@ -315,7 +275,7 @@ function analyticbridge_register_options() {
 
 }
 add_action('admin_init', 'analyticbridge_register_options');
-  
+
 /**
  * Intro text for our google api settings section.
  *
@@ -347,13 +307,12 @@ function largo_anaytic_bridge_account_settings_section_intro() {
 function largo_anaytic_bridge_popular_posts_settings_section_intro() {
 	echo '<p>Enter the half life that popular post pageview weight should degrade by.</p>';
 }
- 
 
 /**
  * Prints input field for Google Client ID setting.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_api_client_id_input() {
 	echo '<input name="analyticbridge_setting_api_client_id" id="analyticbridge_setting_api_client_id" type="text" value="' . analyticbridge_client_id() . '" class="regular-text" />';
 }
@@ -362,7 +321,7 @@ function analyticbridge_setting_api_client_id_input() {
  * Prints input field for Google Client Secret setting.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_api_client_secret_input() {
 	echo '<input name="analyticbridge_setting_api_client_secret" id="analyticbridge_setting_api_client_secret" type="text" value="' . analyticbridge_client_secret() . '" class="regular-text" />';
 }
@@ -371,14 +330,14 @@ function analyticbridge_setting_api_client_secret_input() {
  * Prints input field for Google Client Secret setting.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_api_token_connect_button() {
 
-	if(analyticbridge_client_id() && analyticbridge_client_secret()) :
+	if ( analyticbridge_client_id() && analyticbridge_client_secret() ) {
 
 		// API Tokens are defined.
 
-		if(!get_option('analyticbridge_access_token') ) :
+		if ( ! get_option( 'analyticbridge_access_token' ) ) {
 
 			// Analytic Bridge is Authenticated.
 			$client = analytic_bridge_google_client(false);
@@ -387,7 +346,7 @@ function analyticbridge_setting_api_token_connect_button() {
 				<a href="<?php echo $client->createAuthUrl() ?>"  class='google-button'>Connect to Google Analytics</a>
 				<p class="description">A user with read access to your organizations Google Analytics profile must connect their Google Account.</p>
 			<?
-		else :
+		} else {
 
 			// Analytic Bridge is Authenticated.
 			$client = analytic_bridge_google_client();
@@ -396,42 +355,38 @@ function analyticbridge_setting_api_token_connect_button() {
 			$user = $service->userinfo->get();
 			?>
 
-				<div class="google-chip">
-					<?php if( !empty($user->picture) ) : ?>
-					<span class="google-user-image">
-						<img src="<?php echo $user->picture ?>" />
-					</span>
-					<?php endif; ?>
-					<span class="google-user-name">
-						<?php echo "Authenticated as " . $user->getName(); ?>
-					</span>
-				</div>
-				<!-- todo: <p class="description">Disconnect this user.</p> -->
-				<?php 
-
-				if( get_option('analyticbridge_authenticated_user') ) : 
-
-					$userdata = get_userdata(get_option('analyticbridge_authenticated_user'));
-					$username = $userdata->user_login;
-
-					$authenticated_date = get_option('analyticbridge_authenticated_date_gmt');
-					$authenticated_date = get_date_from_gmt($authenticated_date);
-					$authenticated_date = mysql2date('M d, Y',$authenticated_date);
-
-				?>
-				<p class="description">by WordPress user "<?php echo $username; ?>" on  <?php echo $authenticated_date ?>
+			<div class="google-chip">
+				<?php if( !empty($user->picture) ) : ?>
+				<span class="google-user-image">
+					<img src="<?php echo $user->picture ?>" />
+				</span>
 				<?php endif; ?>
-				
-			<?
+				<span class="google-user-name">
+					<?php echo "Authenticated as " . $user->getName(); ?>
+				</span>
+			</div>
+			<!-- todo: <p class="description">Disconnect this user.</p> -->
+			<?php
 
-		endif;
+			if ( get_option('analyticbridge_authenticated_user') ) {
+				$userdata = get_userdata(get_option('analyticbridge_authenticated_user'));
+				$username = $userdata->user_login;
 
-	else :
+				$authenticated_date = get_option('analyticbridge_authenticated_date_gmt');
+				$authenticated_date = get_date_from_gmt($authenticated_date);
+				$authenticated_date = mysql2date('M d, Y',$authenticated_date);
+			?>
+			<p class="description">by WordPress user "<?php echo $username; ?>" on  <?php echo $authenticated_date ?></p>
+			<?php
+			}
+		}
+
+	} else {
 		?>
 			<span class='google-button disabled'>Google Analytics not connected</span>
 			<p class="description">Enter a Client ID and Client Secret above before connecting Google Analytics.</p>
 		<?php
-	endif;
+	}
 
 }
 
@@ -439,7 +394,7 @@ function analyticbridge_setting_api_token_connect_button() {
  * Prints input field for Google Profile ID to pull data from.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_account_profile_id_input() {
 
 	if( $client = analytic_bridge_google_client(true,$e) ) {
@@ -454,7 +409,7 @@ function analyticbridge_setting_account_profile_id_input() {
  * Prints input field for Popular Post halflife.
  *
  * @since v0.1
- */ 
+ */
 function analyticbridge_setting_popular_posts_halflife_input() {
 	echo '<input name="analyticbridge_setting_popular_posts_halflife" id="analyticbridge_setting_popular_posts_halflife" type="text" value="' . get_option('analyticbridge_setting_popular_posts_halflife') . '" class="regular-text" />';
 }

--- a/inc/analytic-bridge-network-options.php
+++ b/inc/analytic-bridge-network-options.php
@@ -72,4 +72,3 @@ function analyticbridge_update_network_options(){
 	exit;
 }
 add_action('admin_post_network-analytic-bridge-options',  'analyticbridge_update_network_options');
-

--- a/inc/analytic-bridge-network-options.php
+++ b/inc/analytic-bridge-network-options.php
@@ -5,7 +5,6 @@
  * @package Analytic Bridge
  */
 
-
 /**
  * Register *network* option page for the Analytic Bridge.
  *
@@ -24,7 +23,6 @@ function analyticbridge_network_plugin_menu() {
 
 }
 add_action( 'network_admin_menu', 'analyticbridge_network_plugin_menu' );
-
 
 /**
  * Output the html for the *network* option page.
@@ -56,7 +54,6 @@ function analyticbridge_network_option_page_html() {
 	echo '</div>'; // div.wrap
 
 }
-
 
 function analyticbridge_update_network_options(){
 


### PR DESCRIPTION
This PR adds a cleanup task to the analytic bridge cron which, after the plugin has pulled in the most recent metrics records from Google, runs a query to delete any records that we no longer need.

This is in an effort to keep the overall size of the analytic bridge tables to a minimum.
